### PR TITLE
auto-release-pr

### DIFF
--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -10,12 +10,3 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           releasePRNumber: ${{ github.event.pull_request.number }}
-          bodyTemplate: |
-            差分
-
-            {summary}
-
-            以上
-          commentTemplate: |
-            diff
-            {diff}

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -7,4 +7,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./auto-release-pr
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -1,6 +1,6 @@
 name: Test auto-release-pr
 on:
-  push:
+  pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -9,3 +9,4 @@ jobs:
       - uses: ./auto-release-pr
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          releasePRNumber: ${{ github.event.pull_request.number }}

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -1,6 +1,7 @@
 name: Test auto-release-pr
 on:
-  pull_request:
+  # To test, comment-in following line. The PR body will be generated.
+  #pull_request:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -1,3 +1,4 @@
+name: Test auto-release-pr
 on:
   push:
 jobs:

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -10,3 +10,12 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           releasePRNumber: ${{ github.event.pull_request.number }}
+          bodyTemplate: |
+            差分
+
+            {summary}
+
+            以上
+          commentTemplate: |
+            diff
+            {diff}

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -2,6 +2,8 @@ name: Test auto-release-pr
 on:
   # To test, comment-in following line. The PR body will be generated.
   #pull_request:
+  # dummy trigger
+  repository_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -1,0 +1,10 @@
+on:
+  push:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./auto-release-pr
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # github-actions
 Shared Github Actions
+
+- [`auto-release-pr`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr): リリースPRの本文を自動で更新

--- a/auto-release-pr/Dockerfile
+++ b/auto-release-pr/Dockerfile
@@ -4,5 +4,6 @@ ADD . /app
 WORKDIR /app
 
 RUN pip install -r requirements.txt
+RUN ls -lh
 
 CMD ["python", "release-pr.py"]

--- a/auto-release-pr/Dockerfile
+++ b/auto-release-pr/Dockerfile
@@ -4,6 +4,5 @@ ADD . /app
 WORKDIR /app
 
 RUN pip install -r requirements.txt
-RUN ls -lh
 
-CMD ["python", "release-pr.py"]
+CMD ["python", "/app/release-pr.py"]

--- a/auto-release-pr/Dockerfile
+++ b/auto-release-pr/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3
+
+ADD . /app
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+CMD ["python", "release-pr.py"]

--- a/auto-release-pr/README.md
+++ b/auto-release-pr/README.md
@@ -12,9 +12,11 @@
 | パラメータ | Required | Default | |
 |-|-|-|-|
 | `githubToken` | ✔ | | GitHub Token。PRの探索や更新に利用されます。 |
-| `baseBranch` | ✔ | `release` | リリースPRのBase Branch。PRの探索や作成時に利用されます。 |
-| `headBranch` | ✔ | `master` | リリースPRのHead Branch。PRの探索や作成時に利用されます。 |
+| `baseBranch` | | `release` | リリースPRのBase Branch。PRの探索や作成時に利用されます。 |
+| `headBranch` | | `master` | リリースPRのHead Branch。PRの探索や作成時に利用されます。 |
 | `releasePRNumber` | | | リリースPRの番号。 `releasePRNumber` が指定されると `baseBranch`/`headBranch` は無視されます。 |
+| `bodyTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | PR本文の生成テンプレート。テンプレート内の `{summary}` が差分の箇条書きに置き換えられます。 |
+| `commentTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | 本文の更新差分のコメントのテンプレート。テンプレート内の `{diff}` が差分表示に置き換えられます。 |
 
 ## Usage
 

--- a/auto-release-pr/README.md
+++ b/auto-release-pr/README.md
@@ -1,0 +1,68 @@
+# auto-release-pr
+
+リリースPull Requestの本文を自動で書き換えるActionです。
+
+以下の動作をします。
+
+1. 対象となるリリースPRを探索、見つからなければ新たに作成します。
+1. リリースPRに含まれる各コミットのコミットメッセージから含まれているPRの一覧を取得します。
+1. リリースPRの本文を更新して、前後の差分をコメントに残します。
+
+## Inputs
+| パラメータ | Required | Default | |
+|-|-|-|-|
+| `githubToken` | ✔ | | GitHub Token。PRの探索や更新に利用されます。 |
+| `baseBranch` | ✔ | `release` | リリースPRのBase Branch。PRの探索や作成時に利用されます。 |
+| `headBranch` | ✔ | `master` | リリースPRのHead Branch。PRの探索や作成時に利用されます。 |
+| `releasePRNumber` | | | リリースPRの番号。 `releasePRNumber` が指定されると `baseBranch`/`headBranch` は無視されます。 |
+
+## Usage
+
+ブランチ運用フローによって2つの使い方があります。
+
+### `master` ブランチを直接 `release` ブランチに取り込む場合
+
+`master` 向きのPRがマージされるたびに、 `master` から `release` ブランチに向いているPRを探索 or 作成し、その本文を置き換えます。
+
+```yaml
+on:
+  pull_request:
+    types: 
+      - closed
+    branches:
+      - master
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ratel-pay/github-actions/auto-release-pr@master
+          with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          # Set if needed
+          # baseBranch: release
+          # headBranch: master
+```
+
+### リリースのたびにブランチを切ってPull Requestを作成している場合
+
+`release` に向けたPRのBranchが更新されるたびに、その本文を置き換えます。
+
+```yaml
+on:
+  pull_request:
+    types: 
+      - opened
+      - synchronized
+    branches:
+      - release
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ratel-pay/github-actions/auto-release-pr@master
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          releasePRNumber: ${{ github.event.pull_request.number }}
+```

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -1,0 +1,43 @@
+name: Update Release PR
+description: Find or create release Pull Request and update its body automatically.
+inputs:
+  github-token:
+    description: GitHub Token
+    required: true
+outputs:
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - uses: actions/cache@v2
+      if: startsWith(runner.os, 'Linux')
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - uses: actions/cache@v2
+      if: startsWith(runner.os, 'macOS')
+      with:
+        path: ~/Library/Caches/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - uses: actions/cache@v2
+      if: startsWith(runner.os, 'Windows')
+      with:
+        path: ~\AppData\Local\pip\Cache
+        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+    - name: Run
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+        REPO_NAME: ${{ github.repository }}
+      run: |
+        python release-pr.py

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -1,43 +1,10 @@
 name: Update Release PR
 description: Find or create release Pull Request and update its body automatically.
 inputs:
-  github-token:
+  githubToken:
     description: GitHub Token
     required: true
 outputs:
 runs:
-  using: "composite"
-  steps:
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - uses: actions/cache@v2
-      if: startsWith(runner.os, 'Linux')
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - uses: actions/cache@v2
-      if: startsWith(runner.os, 'macOS')
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - uses: actions/cache@v2
-      if: startsWith(runner.os, 'Windows')
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        pip install -r requirements.txt
-    - name: Run
-      env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
-        REPO_NAME: ${{ github.repository }}
-      run: |
-        python release-pr.py
+  using: "docker"
+  image: "Dockerfile"

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -4,7 +4,6 @@ inputs:
   githubToken:
     description: GitHub Token
     required: true
-outputs:
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -19,6 +19,31 @@ inputs:
   releasePRNumber:
     description: The number of release Pull Request.
     required: false
+  bodyTemplate:
+    description: |
+      The template of generating release Pull Request.
+      `{summary}` will be replaced by generating body.
+    required: true
+    default: |
+      ## Changes
+
+      {summary}
+  commentTemplate:
+    description: |
+      The template of generating comment.
+      `{diff}` will be replaced by diff.
+    required: true
+    default: |
+      PR body is updated!
+      <details><summary>diff</summary>
+      <p>
+
+      ```diff
+      {diff}
+      ```
+
+      </p>
+      </detail>
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -4,6 +4,21 @@ inputs:
   githubToken:
     description: GitHub Token
     required: true
+  baseBranch:
+    description: |
+      The base branch of Pull Request to find.
+      It will be ignored if `releasePRNumber` is passed.
+    required: true
+    default: release
+  headBranch:
+    description: |
+      The head branch of Pull Request to find.
+      It will be ignored if `releasePRNumber` is passed.
+    required: true
+    default: master
+  releasePRNumber:
+    description: The number of release Pull Request.
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -22,7 +22,7 @@ inputs:
   bodyTemplate:
     description: |
       The template of generating release Pull Request.
-      `{summary}` will be replaced by generating body.
+      `{summary}` will be replaced with generating body.
     required: true
     default: |
       ## Changes
@@ -31,7 +31,7 @@ inputs:
   commentTemplate:
     description: |
       The template of generating comment.
-      `{diff}` will be replaced by diff.
+      `{diff}` will be replaced with diff.
     required: true
     default: |
       PR body is updated!

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -65,7 +65,8 @@ def make_new_body(pr: github.PullRequest.PullRequest) -> Optional[str]:
 
         return f'- {number}: {title}'
 
-    body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
+    # body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
+    body_lines = '\n'.join([f'- {m}' for m in commit_messages])
     if len(body_lines) > 0:
         return '## Changes\n\n' + body_lines
     else:

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -7,8 +7,8 @@ import re
 import sys
 
 
-GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
-REPO_NAME = os.environ['REPO_NAME']
+GITHUB_TOKEN = os.environ['INPUT_GITHUBTOKEN']
+REPO_NAME = os.environ['GITHUB_REPOSITORY']
 
 COMMENT_TEMPLATE = '''PR body is updated!
 <details><summary>diff</summary>

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -1,0 +1,92 @@
+import github
+
+from typing import Optional
+import difflib
+import os
+import re
+import sys
+
+
+GITHUB_TOKEN = os.environ['GITHUB_TOKEN']
+REPO_NAME = os.environ['REPO_NAME']
+
+COMMENT_TEMPLATE = '''PR body is updated!
+<details><summary>diff</summary>
+<p>
+
+```diff
+{diff}
+```
+
+</p>
+</detail>
+'''
+
+
+# release 向きの最新 PR を取得
+def find_latest_release_pr(repo: github.Repository.Repository) -> Optional[github.PullRequest.PullRequest]:	
+    prs = repo.get_pulls(state='open', base='release', head='master', sort='created', direction='desc')	
+
+    if prs.totalCount > 0:	
+        return prs[0]	
+    else:	
+        return None
+
+# release 向きの最新 PR を取得を探して、なかったら作成する
+def find_or_create_release_pr(repo: github.Repository.Repository) -> github.PullRequest.PullRequest:	
+    latest = find_latest_release_pr(repo)
+    if latest:
+        return latest
+    else:
+        return repo.create_pull(title='[リリース]',
+                                body='',
+                                base='release',
+                                head='master',
+                                draft=True)
+
+# PR のコミットメッセージから含まれる PR を探して新しいの PR の body を作る
+def make_new_body(pr: github.PullRequest.PullRequest) -> Optional[str]:
+    commit_messages = [cm.commit.message for cm in pr.get_commits()]
+    merge_commit_messages = [m for m in commit_messages if m.startswith("Merge pull request")]
+
+    # 複数行のコミットメッセージから箇条書きの一行を生成する
+    def convert_to_body_line(message: str) -> str:
+        lines = message.splitlines()
+
+        number = re.search(r'#\d+', lines[0]).group()
+        title = lines[2]
+
+        return f'- {number}: {title}'
+
+    body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
+    if len(body_lines) > 0:
+        return '## Changes\n\n' + body_lines
+    else:
+        return None
+
+def main():
+    g = github.Github(GITHUB_TOKEN)
+    repo = g.get_repo(REPO_NAME)
+    release_pr = find_or_create_release_pr(repo)
+
+    # body を生成
+    new_body = make_new_body(release_pr)
+    if not new_body:
+        print("Failed to generate new PR body.")
+        sys.exit(1)
+
+    # diff を生成
+    old_body_lines = release_pr.body.splitlines()
+    new_body_lines = new_body.splitlines() 
+    diff = '\n'.join(difflib.unified_diff(old_body_lines, new_body_lines))
+
+    # PR 本文を更新
+    release_pr.edit(body=new_body)
+
+    # comment に diff を残す
+    comment_body = COMMENT_TEMPLATE.format(diff=diff)
+    release_pr.as_issue().create_comment(comment_body)
+
+
+if __name__ == "__main__":
+    main()

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -55,8 +55,7 @@ def make_new_body(pr: github.PullRequest.PullRequest, template: str) -> Optional
 
         return f'- {number}: {title}'
 
-    # body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
-    body_lines = '\n'.join([f'- {m.splitlines()[0]}' for m in commit_messages])
+    body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
     if len(body_lines) > 0:
         return template.format(summary=body_lines)
     else:

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -47,8 +47,8 @@ def find_or_create_release_pr(repo: github.Repository.Repository, base: str, hea
     else:
         return repo.create_pull(title='[リリース]',
                                 body='',
-                                base='release',
-                                head='master',
+                                base=base,
+                                head=head,
                                 draft=True)
 
 # PR のコミットメッセージから含まれる PR を探して新しいの PR の body を作る

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -55,7 +55,8 @@ def make_new_body(pr: github.PullRequest.PullRequest, template: str) -> Optional
 
         return f'- {number}: {title}'
 
-    body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
+    # body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
+    body_lines = '\n'.join([f'- {m.splitlines()[0]}' for m in commit_messages])
     if len(body_lines) > 0:
         return template.format(summary=body_lines)
     else:

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -7,8 +7,12 @@ import re
 import sys
 
 
-GITHUB_TOKEN = os.environ['INPUT_GITHUBTOKEN']
-REPO_NAME = os.environ['GITHUB_REPOSITORY']
+GITHUB_TOKEN: str = os.environ['INPUT_GITHUBTOKEN']
+REPO_NAME: str = os.environ['GITHUB_REPOSITORY']
+BASE_BRANCH: str = os.environ['INPUT_BASEBRANCH']
+HEAD_BRANCH: str = os.environ['INPUT_HEADBRANCH']
+RELEASE_PR_NUMBER: Optional[str] = os.environ.get('INPUT_RELEASEPRNUMBER')
+
 
 COMMENT_TEMPLATE = '''PR body is updated!
 <details><summary>diff</summary>
@@ -24,8 +28,8 @@ COMMENT_TEMPLATE = '''PR body is updated!
 
 
 # release 向きの最新 PR を取得
-def find_latest_release_pr(repo: github.Repository.Repository) -> Optional[github.PullRequest.PullRequest]:	
-    prs = repo.get_pulls(state='open', base='release', head='master', sort='created', direction='desc')	
+def find_latest_release_pr(repo: github.Repository.Repository, base: str, head: str) -> Optional[github.PullRequest.PullRequest]:	
+    prs = repo.get_pulls(state='open', base=base, head=head, sort='created', direction='desc')	
 
     if prs.totalCount > 0:	
         return prs[0]	
@@ -33,7 +37,10 @@ def find_latest_release_pr(repo: github.Repository.Repository) -> Optional[githu
         return None
 
 # release 向きの最新 PR を取得を探して、なかったら作成する
-def find_or_create_release_pr(repo: github.Repository.Repository) -> github.PullRequest.PullRequest:	
+def find_or_create_release_pr(repo: github.Repository.Repository, base: str, head: str, number: Optional[str]) -> github.PullRequest.PullRequest:	
+    if number:
+        return repo.get_pull(int(number))
+
     latest = find_latest_release_pr(repo)
     if latest:
         return latest
@@ -67,7 +74,7 @@ def make_new_body(pr: github.PullRequest.PullRequest) -> Optional[str]:
 def main():
     g = github.Github(GITHUB_TOKEN)
     repo = g.get_repo(REPO_NAME)
-    release_pr = find_or_create_release_pr(repo)
+    release_pr = find_or_create_release_pr(repo, base=BASE_BRANCH, head=HEAD_BRANCH, number=RELEASE_PR_NUMBER)
 
     # body を生成
     new_body = make_new_body(release_pr)

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -65,8 +65,7 @@ def make_new_body(pr: github.PullRequest.PullRequest) -> Optional[str]:
 
         return f'- {number}: {title}'
 
-    # body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
-    body_lines = '\n'.join([f'- {m}' for m in commit_messages])
+    body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
     if len(body_lines) > 0:
         return '## Changes\n\n' + body_lines
     else:

--- a/auto-release-pr/requirements.txt
+++ b/auto-release-pr/requirements.txt
@@ -1,0 +1,9 @@
+certifi==2020.6.20
+chardet==3.0.4
+Deprecated==1.2.10
+idna==2.10
+PyGithub==1.53
+PyJWT==1.7.1
+requests==2.24.0
+urllib3==1.25.10
+wrapt==1.12.1


### PR DESCRIPTION
自動リリースPRのActionを共通で使えるように移植しました。

内部で利用していたものからの差分は

- 各リポジトリのブランチ運用に対応できるように `baseBranch`/`headBranch`/`releasePRNumber` のパラメーターを追加
- PR本文とコメントのテンプレートをパラメーターで渡せるように改善

です。

GitHub Actionsの[composite run steps action](https://docs.github.com/en/actions/creating-actions/creating-a-composite-run-steps-action)ではまだ `uses` をつかった既存のActionの利用ができないため、暫定的にDockerベースのActionとして構築しました。
毎回 `docker build` が走りますが、それを含めて1分以内で完了しているので一旦許容したいです。

ActionsのIssue(https://github.com/actions/runner/issues/646)では `uses` の利用もロードマップに入っているようなので、実装されたら移行する予定です。
