### PR TITLE
auto-release-prでタイトルとラベルを指定できるようにする

### DIFF
--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -1,9 +1,9 @@
 name: Test auto-release-pr
 on:
   # To test, comment-in following line. The PR body will be generated.
-  #pull_request:
+  pull_request:
   # dummy trigger
-  repository_dispatch:
+  #repository_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,3 +13,4 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           releasePRNumber: ${{ github.event.pull_request.number }}
+          releasePRLabel: bug

--- a/.github/workflows/auto-release-pr-test.yml
+++ b/.github/workflows/auto-release-pr-test.yml
@@ -1,9 +1,9 @@
 name: Test auto-release-pr
 on:
   # To test, comment-in following line. The PR body will be generated.
-  pull_request:
+  #pull_request:
   # dummy trigger
-  #repository_dispatch:
+  repository_dispatch:
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,4 +13,3 @@ jobs:
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           releasePRNumber: ${{ github.event.pull_request.number }}
-          releasePRLabel: bug

--- a/auto-release-pr/README.md
+++ b/auto-release-pr/README.md
@@ -17,6 +17,7 @@
 | `releasePRNumber` | | | リリースPRの番号。 `releasePRNumber` が指定されると `baseBranch`/`headBranch` は無視されます。 |
 | `bodyTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | PR本文の生成テンプレート。テンプレート内の `{summary}` が差分の箇条書きに置き換えられます。 |
 | `commentTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | 本文の更新差分のコメントのテンプレート。テンプレート内の `{diff}` が差分表示に置き換えられます。 |
+| `releasePRLabel` | | | リリースPRにつけるラベル。新規作成時や既存のものに付与されていなかったときは新たに付与されます。 |
 
 ## Usage
 

--- a/auto-release-pr/README.md
+++ b/auto-release-pr/README.md
@@ -18,6 +18,7 @@
 | `bodyTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | PR本文の生成テンプレート。テンプレート内の `{summary}` が差分の箇条書きに置き換えられます。 |
 | `commentTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | 本文の更新差分のコメントのテンプレート。テンプレート内の `{diff}` が差分表示に置き換えられます。 |
 | `releasePRLabel` | | | リリースPRにつけるラベル。新規作成時や既存のものに付与されていなかったときは新たに付与されます。 |
+| `newReleasePRTitle` | | `[リリース]` | 新規作成するリリースPRのタイトル |
 
 ## Usage
 

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -47,6 +47,10 @@ inputs:
   releasePRLabel:
     description: The label for release Pull Request.
     required: false
+  newReleasePRTitle:
+    description: The title of new release Pull Request.
+    required: true
+    default: "[リリース]"
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -44,6 +44,9 @@ inputs:
 
       </p>
       </detail>
+  label:
+    description: The label for release Pull Request.
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -44,7 +44,7 @@ inputs:
 
       </p>
       </detail>
-  prLabel:
+  releasePRLabel:
     description: The label for release Pull Request.
     required: false
 runs:

--- a/auto-release-pr/action.yml
+++ b/auto-release-pr/action.yml
@@ -44,7 +44,7 @@ inputs:
 
       </p>
       </detail>
-  label:
+  prLabel:
     description: The label for release Pull Request.
     required: false
 runs:

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -49,7 +49,7 @@ def add_label(pr: github.PullRequest.PullRequest, label: Optional[str]):
     if not label:
         return
     
-    pr.add_to_labels([label])
+    pr.add_to_labels(label)
 
 # PR のコミットメッセージから含まれる PR を探して新しいの PR の body を作る
 def make_new_body(pr: github.PullRequest.PullRequest, template: str) -> Optional[str]:

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -17,6 +17,8 @@ BODY_TEMPLATE: str = os.environ['INPUT_BODYTEMPLATE']
 COMMENT_TEMPLATE: str = os.environ['INPUT_COMMENTTEMPLATE']
 RELEASE_PR_LABEL: Optional[str] = os.environ.get('INPUT_RELEASEPRLABEL')
 
+NEW_RELEASE_PR_TITLE: str = os.environ['INPUT_NEWRELEASEPRTITLE']
+
 
 # release 向きの最新 PR を取得
 def find_latest_release_pr(repo: github.Repository.Repository, base: str, head: str) -> Optional[github.PullRequest.PullRequest]:	
@@ -28,7 +30,7 @@ def find_latest_release_pr(repo: github.Repository.Repository, base: str, head: 
         return None
 
 # release 向きの最新 PR を取得を探して、なかったら作成する
-def find_or_create_release_pr(repo: github.Repository.Repository, base: str, head: str, number: Optional[str]) -> github.PullRequest.PullRequest:	
+def find_or_create_release_pr(repo: github.Repository.Repository, base: str, head: str, number: Optional[str], new_title: str) -> github.PullRequest.PullRequest:	
     if number:
         return repo.get_pull(int(number))
 
@@ -36,7 +38,7 @@ def find_or_create_release_pr(repo: github.Repository.Repository, base: str, hea
     if latest:
         return latest
     else:
-        return repo.create_pull(title='[リリース]',
+        return repo.create_pull(title=new_title,
                                 body='',
                                 base=base,
                                 head=head,
@@ -72,7 +74,7 @@ def make_new_body(pr: github.PullRequest.PullRequest, template: str) -> Optional
 def main():
     g = github.Github(GITHUB_TOKEN)
     repo = g.get_repo(REPO_NAME)
-    release_pr = find_or_create_release_pr(repo, base=BASE_BRANCH, head=HEAD_BRANCH, number=RELEASE_PR_NUMBER)
+    release_pr = find_or_create_release_pr(repo, base=BASE_BRANCH, head=HEAD_BRANCH, number=RELEASE_PR_NUMBER, new_title=NEW_RELEASE_PR_TITLE)
 
     add_label(release_pr, label=RELEASE_PR_LABEL)
 

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -15,7 +15,7 @@ RELEASE_PR_NUMBER: Optional[str] = os.environ.get('INPUT_RELEASEPRNUMBER')
 
 BODY_TEMPLATE: str = os.environ['INPUT_BODYTEMPLATE']
 COMMENT_TEMPLATE: str = os.environ['INPUT_COMMENTTEMPLATE']
-RELEASE_PR_LABEL: Optional[str] = os.environ.get('INPUT_LABEL')
+RELEASE_PR_LABEL: Optional[str] = os.environ.get('INPUT_PRLABEL')
 
 
 # release 向きの最新 PR を取得

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -15,6 +15,7 @@ RELEASE_PR_NUMBER: Optional[str] = os.environ.get('INPUT_RELEASEPRNUMBER')
 
 BODY_TEMPLATE: str = os.environ['INPUT_BODYTEMPLATE']
 COMMENT_TEMPLATE: str = os.environ['INPUT_COMMENTTEMPLATE']
+RELEASE_PR_LABEL: Optional[str] = os.environ.get('INPUT_LABEL')
 
 
 # release 向きの最新 PR を取得
@@ -41,6 +42,13 @@ def find_or_create_release_pr(repo: github.Repository.Repository, base: str, hea
                                 head=head,
                                 draft=True)
 
+# PR にラベル付与
+def add_label(pr: github.PullRequest.PullRequest, label: Optional[str]):
+    if not label:
+        return
+    
+    pr.add_to_labels([label])
+
 # PR のコミットメッセージから含まれる PR を探して新しいの PR の body を作る
 def make_new_body(pr: github.PullRequest.PullRequest, template: str) -> Optional[str]:
     commit_messages = [cm.commit.message for cm in pr.get_commits()]
@@ -65,6 +73,8 @@ def main():
     g = github.Github(GITHUB_TOKEN)
     repo = g.get_repo(REPO_NAME)
     release_pr = find_or_create_release_pr(repo, base=BASE_BRANCH, head=HEAD_BRANCH, number=RELEASE_PR_NUMBER)
+
+    add_label(release_pr, label=RELEASE_PR_LABEL)
 
     # body を生成
     new_body = make_new_body(release_pr, template=BODY_TEMPLATE)

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -15,7 +15,7 @@ RELEASE_PR_NUMBER: Optional[str] = os.environ.get('INPUT_RELEASEPRNUMBER')
 
 BODY_TEMPLATE: str = os.environ['INPUT_BODYTEMPLATE']
 COMMENT_TEMPLATE: str = os.environ['INPUT_COMMENTTEMPLATE']
-RELEASE_PR_LABEL: Optional[str] = os.environ.get('INPUT_PRLABEL')
+RELEASE_PR_LABEL: Optional[str] = os.environ.get('INPUT_RELEASEPRLABEL')
 
 
 # release 向きの最新 PR を取得


### PR DESCRIPTION
以下のパラメーターを追加しました

- `releasePRLabel`
  - Optional
  - find_or_createしたリリースPRに付加するラベルです
- `newReleasePRTitle`
  - リリースPRを新規作成したときのタイトルです