### PR TITLE
#4 のスクリプトを修正

### DIFF
--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -60,10 +60,10 @@ def make_new_body(repo: github.Repository.Repository, pr: github.PullRequest.Pul
     def convert_to_body_line(message: str) -> str:
         lines = message.splitlines()
 
-        number = re.search(r'#\d+', lines[0]).group()
+        number = re.search(r'#(\d+)', lines[0]).group(1)
         title = repo.get_pull(int(number)).title
 
-        return f'- {number}: {title}'
+        return f'- #{number}: {title}'
 
     body_lines = '\n'.join(map(convert_to_body_line, merge_commit_messages))
     if len(body_lines) > 0:


### PR DESCRIPTION
#4 のスクリプトで `number` に `#111` のような `#` つきの文字列が入ってきてしまうに対応しました。

手元でそれっぽい環境変数を与えて動作確認済みです。