### PR TITLE
bodyがないPRでコケてしまう問題を修正

### DIFF
--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -85,7 +85,7 @@ def main():
         sys.exit(1)
 
     # diff を生成
-    old_body_lines = release_pr.body.splitlines()
+    old_body_lines = (release_pr.body if release_pr.body else '').splitlines()
     new_body_lines = new_body.splitlines() 
     diff = '\n'.join(difflib.unified_diff(old_body_lines, new_body_lines))
 


### PR DESCRIPTION
新規PRの場合、 `body = None` となってコケてしまっていたので修正しました。