### PR TITLE
コメント時のテンプレートに新規PRの情報を渡せるように

### DIFF
--- a/auto-release-pr/README.md
+++ b/auto-release-pr/README.md
@@ -16,7 +16,7 @@
 | `headBranch` | | `master` | リリースPRのHead Branch。PRの探索や作成時に利用されます。 |
 | `releasePRNumber` | | | リリースPRの番号。 `releasePRNumber` が指定されると `baseBranch`/`headBranch` は無視されます。 |
 | `bodyTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | PR本文の生成テンプレート。テンプレート内の `{summary}` が差分の箇条書きに置き換えられます。 |
-| `commentTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | 本文の更新差分のコメントのテンプレート。テンプレート内の `{diff}` が差分表示に置き換えられます。 |
+| `commentTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | 本文の更新差分のコメントのテンプレート。テンプレート内の `{diff}` が差分表示に、`{new_line}`が新規差分に置き換えられます。 |
 | `releasePRLabel` | | | リリースPRにつけるラベル。新規作成時や既存のものに付与されていなかったときは新たに付与されます。 |
 | `newReleasePRTitle` | | `[リリース]` | 新規作成するリリースPRのタイトル |
 

--- a/auto-release-pr/README.md
+++ b/auto-release-pr/README.md
@@ -16,7 +16,7 @@
 | `headBranch` | | `master` | リリースPRのHead Branch。PRの探索や作成時に利用されます。 |
 | `releasePRNumber` | | | リリースPRの番号。 `releasePRNumber` が指定されると `baseBranch`/`headBranch` は無視されます。 |
 | `bodyTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | PR本文の生成テンプレート。テンプレート内の `{summary}` が差分の箇条書きに置き換えられます。 |
-| `commentTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | 本文の更新差分のコメントのテンプレート。テンプレート内の `{diff}` が差分表示に、`{new_line}`が新規差分に置き換えられます。 |
+| `commentTemplate` | | [`action.yml`](https://github.com/ratel-pay/github-actions/blob/master/auto-release-pr/action.yml) を参照 | 本文の更新差分のコメントのテンプレート。テンプレート内の `{diff}` が差分表示に、`{new_line}`が新規差分の先頭一行目に置き換えられます。 |
 | `releasePRLabel` | | | リリースPRにつけるラベル。新規作成時や既存のものに付与されていなかったときは新たに付与されます。 |
 | `newReleasePRTitle` | | `[リリース]` | 新規作成するリリースPRのタイトル |
 

--- a/auto-release-pr/release-pr.py
+++ b/auto-release-pr/release-pr.py
@@ -88,12 +88,13 @@ def main():
     old_body_lines = (release_pr.body if release_pr.body else '').splitlines()
     new_body_lines = new_body.splitlines() 
     diff = '\n'.join(difflib.unified_diff(old_body_lines, new_body_lines))
-
+    new_line = [line for line in new_body_lines if line not in old_body_lines][0]
+   
     # PR 本文を更新
     release_pr.edit(body=new_body)
 
     # comment に diff を残す
-    comment_body = COMMENT_TEMPLATE.format(diff=diff)
+    comment_body = COMMENT_TEMPLATE.format(diff=diff, new_line=new_line)
     release_pr.as_issue().create_comment(comment_body)
 
 


### PR DESCRIPTION
## 概要
 - 3915 に付随するactionsの変更
 - comment時のtemplateに対して、新規行を渡せるように変更
 ※ こちらのactionは都度実行されるはずなので、配列の先頭のみを対象として取得しています。