### PR TITLE
CodeBuild の buildspec の上書きジョブに正しく渡っていなかった部分を修正

### DIFF
--- a/.github/workflows/kick-codebuild.yaml
+++ b/.github/workflows/kick-codebuild.yaml
@@ -13,7 +13,6 @@ on:
         type: string
         default: buildspec.yml
 
-
 jobs:
   execute:
     runs-on: ubuntu-latest
@@ -30,4 +29,4 @@ jobs:
         uses: aws-actions/aws-codebuild-run-build@v1
         with:
           project-name: ${{ inputs.codebuild_project_name }}
-          buildspec-override: ${{ inputs.buildspec }}
+          buildspec-override: ${{ inputs.codebuild_buildspec }}


### PR DESCRIPTION
よくみたら、`workflow_call` で受ける引数名と `aws-actions/aws-codebuild-run-build@v1` に渡している引数名の名前がことなっており、正しく渡せていないことに気づいきました 😇 