### PR TITLE
auto-release-pr の Python のバージョンを固定

### DIFF
--- a/auto-release-pr/Dockerfile
+++ b/auto-release-pr/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.10
 
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
突然以下のようなエラーメッセージで死ぬようになってしまった。

```
Traceback (most recent call last):
  File "/app/release-pr.py", line 1, in <module>
    import github
  File "/usr/local/lib/python3.11/site-packages/github/__init__.py", line 58, in <module>
    from github.MainClass import Github, GithubIntegration
  File "/usr/local/lib/python3.11/site-packages/github/MainClass.py", line 62, in <module>
    import github.Event
  File "/usr/local/lib/python3.11/site-packages/github/Event.py", line 34, in <module>
    import github.NamedUser
  File "/usr/local/lib/python3.11/site-packages/github/NamedUser.py", line [46](https://github.com/ratel-pay/payment-analysis/actions/runs/3317955020/jobs/5481365221#step:4:47), in <module>
    import github.Organization
  File "/usr/local/lib/python3.11/site-packages/github/Organization.py", line 52, in <module>
    import github.Repository
  File "/usr/local/lib/python3.11/site-packages/github/Repository.py", line 93, in <module>
    from deprecated import deprecated
  File "/usr/local/lib/python3.11/site-packages/deprecated/__init__.py", line 13, in <module>
    from deprecated.classic import deprecated
  File "/usr/local/lib/python3.11/site-packages/deprecated/classic.py", line 15, in <module>
    import wrapt
  File "/usr/local/lib/python3.11/site-packages/wrapt/__init__.py", line 10, in <module>
    from .decorators import (adapter_factory, AdapterFactory, decorator,
  File "/usr/local/lib/python3.11/site-packages/wrapt/decorators.py", line 34, in <module>
    from inspect import ismethod, isclass, formatargspec
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/local/lib/python3.11/inspect.py)
```

どうやら `python:3` のイメージは 3.11 で動いているらしく、

```
  File "/usr/local/lib/python3.11/site-packages/wrapt/decorators.py", line 34, in <module>
    from inspect import ismethod, isclass, formatargspec
ImportError: cannot import name 'formatargspec' from 'inspect' (/usr/local/lib/python3.11/inspect.py)
```

このあたりが原因なよう。調べてみると、https://docs.python.org/3.11/whatsnew/3.11.html によれば、

> Removed from the [inspect](https://docs.python.org/3.11/library/inspect.html#module-inspect) module:
> - The formatargspec() function, deprecated since Python 3.5; use the [inspect.signature()](https://docs.python.org/3.11/library/inspect.html#inspect.signature) function or the [inspect.Signature](https://docs.python.org/3.11/library/inspect.html#inspect.Signature) object directly.

とか書かれているので内部で使っているモジュールが消えた模様。そんなわけで一旦 3.10 の方に固定しておきます。
