### PR TITLE
kick-codebuild workflow に platform パラメータを追加

### DIFF
--- a/.github/workflows/kick-codebuild.yaml
+++ b/.github/workflows/kick-codebuild.yaml
@@ -12,10 +12,14 @@ on:
         required: false
         type: string
         default: buildspec.yml
+      platform:
+        required: false
+        type: string
+        default: ubuntu-latest
 
 jobs:
   execute:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.platform }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/kick-codebuild/README.md
+++ b/kick-codebuild/README.md
@@ -20,6 +20,7 @@ GitHub Actions の機能である、 [Reusing workflows](https://docs.github.com
 | `aws_account_id` | ✔ | | 実行する AWS アカウントの ID |
 | `codebuild_project_name` | ✔ | | CodeBuild のプロジェクト名 |
 | `codebuild_buildspec` | | `buildspec.yml` | 実行する buildspec を上書きすることができます。 |
+| `platform` | | `ubuntu-latest` | ジョブを実行するマシンの種類を上書きすることができます。 |
 
 ## Usage
 


### PR DESCRIPTION
## 概要

kick-codebuild workflow に platform パラメータを追加し job の runs-on を上書きできるようにします。