### PR TITLE
kick-codebuild workflow に timeout_minutes パラメータを追加

### DIFF
--- a/.github/workflows/kick-codebuild.yaml
+++ b/.github/workflows/kick-codebuild.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: buildspec.yml
+      timeout_minutes:
+        required: false
+        type: number
+        default: 10
       platform:
         required: false
         type: string
@@ -20,6 +24,7 @@ on:
 jobs:
   execute:
     runs-on: ${{ inputs.platform }}
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     steps:
       - uses: actions/checkout@v3
         with:

--- a/kick-codebuild/README.md
+++ b/kick-codebuild/README.md
@@ -20,6 +20,7 @@ GitHub Actions の機能である、 [Reusing workflows](https://docs.github.com
 | `aws_account_id` | ✔ | | 実行する AWS アカウントの ID |
 | `codebuild_project_name` | ✔ | | CodeBuild のプロジェクト名 |
 | `codebuild_buildspec` | | `buildspec.yml` | 実行する buildspec を上書きすることができます。 |
+| `timeout_minutes` | | `10` | ジョブを実行する最長時間を上書きすることができます。 |
 | `platform` | | `ubuntu-latest` | ジョブを実行するマシンの種類を上書きすることができます。 |
 
 ## Usage


### PR DESCRIPTION
## 概要

kick-codebuild workflow に timeout_minutes パラメータを追加し job の timeout-minutes を上書きできるようにします。

デフォルトは 360 (分)
https://docs.github.com/ja/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes